### PR TITLE
Change default API gateway URL & untrack `.env` file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_GATEWAY_URL=https://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-REACT_APP_GATEWAY_URL=https://localhost:8000
+REACT_APP_GATEWAY_URL=https://435eaf3a-a3e0-4168-a95c-1266c99b6bf8.mock.pstmn.io

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+### dotenv ###
+.env


### PR DESCRIPTION
Use the mock server as the default API gateway so we can quickly test frontend features.